### PR TITLE
query by authorId and name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-ratings",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-ratings",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A microservice for handlingy learning object ratings in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -7,3 +7,13 @@ export const LEARNING_OBJECT_SERVICE_ROUTES = {
       )}/id`;
     }
 };
+
+export const USER_SERVICE_ROUTES = {
+  GET_ID(author: string) {
+    return `${
+      process.env.USER_SERVICE_URI
+    }/users/update?username=${encodeURIComponent(
+      author
+    )}`;
+  }
+};


### PR DESCRIPTION
Hotfix for bug where learning object id was being queried by only lo name

Note: All code relevant to this PR will be obsolete when #16 is merged because learning object ids will be passed as a route param.