### PR TITLE
Remove $toString and add toString helper methods in RatingStore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-ratings",
-  "version": "1.1.0",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-ratings",
-  "version": "1.1.0",
+  "version": "1.1.3",
   "description": "A microservice for handlingy learning object ratings in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/ratings/RatingStore.spec.ts
+++ b/src/ratings/RatingStore.spec.ts
@@ -35,17 +35,6 @@ describe('RatingStore', () => {
         });
     });
 
-    describe('getUsersRatings', () => {
-        it('Should fetch all ratings that belong to a user', () => {
-          expect.assertions(1);
-          return expect(driver.getUsersRatings({
-            username: MOCK_OBJECTS.USER.username,
-          }))
-          .resolves
-          .toEqual(MOCK_OBJECTS.USER_GROUPING);
-        });
-    });
-
     describe('createNewRating', () => {
       it('Should fetch all ratings that belong to a learning object', () => {
         expect.assertions(1);

--- a/src/ratings/RatingStore.ts
+++ b/src/ratings/RatingStore.ts
@@ -256,7 +256,7 @@ export class RatingStore implements RatingDataStore {
      */
     convertMongoId(ratings: any) {
       const root = { ...ratings, _id: ratings._id.toString()};
-      root.ratings = root.ratings.map(rating => this.convertRatingObjectId(rating));
+      root.ratings = root.ratings.map((rating: any) => this.convertRatingObjectId(rating));
       return root;
     }
 
@@ -265,7 +265,7 @@ export class RatingStore implements RatingDataStore {
      */
     convertRatingObjectId(rating: any) {
       if (rating.response.length > 0) {
-        rating.response = rating.response.map(response => this.convertResponseObjectId(response));
+        rating.response = rating.response.map((response: any) => this.convertResponseObjectId(response));
       }
       return {...rating, _id: rating._id.toString() };
     }

--- a/src/ratings/RatingStore.ts
+++ b/src/ratings/RatingStore.ts
@@ -202,56 +202,6 @@ export class RatingStore implements RatingDataStore {
     }
 
     /**
-     * Find all ratings that belong to a given user
-     * @export
-     * @param params
-     * @property { string } username: username of the rating author
-     *
-     * @returns { Promise<Rating[]> }
-     */
-    async getUsersRatings(params: {
-      username: string;
-    }): Promise<any> {
-      try {
-        const data = await this.db.collection(Collections.RATINGS)
-          .aggregate(
-          [
-            {
-              $match: { 'user.username': params.username },
-            },
-            {
-              $sort: { date: 1 },
-            },
-            {
-              $group: {
-                _id: '$source',
-                avgValue: {
-                  $avg: '$value',
-                },
-                ratings: {
-                  $push: {
-                    _id: '$_id',
-                    value: '$value',
-                    user: '$user',
-                    comment: '$comment',
-                    date: '$date',
-                  },
-                },
-              },
-            },
-          ],
-        ).toArray();
-        return data[0];
-      } catch (error) {
-        reportError(error);
-        return Promise.reject(new ServiceError(
-            ServiceErrorReason.INTERNAL,
-          ),
-        );
-      }
-    }
-
-    /**
      * Converts MongoDB ObjectId to string
      */
     convertMongoId(ratings: any) {

--- a/src/ratings/RatingStore.ts
+++ b/src/ratings/RatingStore.ts
@@ -138,17 +138,13 @@ export class RatingStore implements RatingDataStore {
             },
             {
               $group: {
-                _id: {
-                  $toString: '$source',
-                },
+                _id: '$source',
                 avgValue: {
                   $avg: '$value',
                 },
                 ratings: {
                   $push: {
-                    _id: {
-                      $toString: '$_id',
-                    },
+                    _id: '$_id',
                     value: '$value',
                     user: '$user',
                     comment: '$comment',
@@ -160,7 +156,8 @@ export class RatingStore implements RatingDataStore {
             },
           ],
         ).toArray();
-        return data[0];
+        const result = this.convertMongoId(data[0]);
+        return result;
       } catch (error) {
         reportError(error);
         return Promise.reject(new ServiceError(
@@ -227,17 +224,13 @@ export class RatingStore implements RatingDataStore {
             },
             {
               $group: {
-                _id: {
-                  $toString: '$source',
-                },
+                _id: '$source',
                 avgValue: {
                   $avg: '$value',
                 },
                 ratings: {
                   $push: {
-                    _id: {
-                      $toString: '$_id',
-                    },
+                    _id: '$_id',
                     value: '$value',
                     user: '$user',
                     comment: '$comment',
@@ -256,6 +249,32 @@ export class RatingStore implements RatingDataStore {
           ),
         );
       }
+    }
+
+    /**
+     * Converts MongoDB ObjectId to string
+     */
+    convertMongoId(ratings: any) {
+      const root = { ...ratings, _id: ratings._id.toString()};
+      root.ratings = root.ratings.map(rating => this.convertRatingObjectId(rating));
+      return root;
+    }
+
+    /**
+     * Iterates through the array of ratings and converts MongoDB ObjectIds to strings
+     */
+    convertRatingObjectId(rating: any) {
+      if (rating.response.length > 0) {
+        rating.response = rating.response.map(response => this.convertResponseObjectId(response));
+      }
+      return {...rating, _id: rating._id.toString() };
+    }
+
+    /**
+     * Iterates through the array of responses and converts MongoDB ObjectIds to strings
+     */
+    convertResponseObjectId(response: any) {
+      return {...response, _id: response._id.toString(), source: response.source.toString() };
     }
 }
 

--- a/src/ratings/RatingsInteractor.ts
+++ b/src/ratings/RatingsInteractor.ts
@@ -200,34 +200,6 @@ export async function createRating(params: {
     }
 }
 
-/**
- * Fetch all ratings for a given user
- * @Authorization
- * *** Admin Editor Reviewer@collection Curator@collection ***
- * @export
- * @param params
- * @property { RatingDataStore } dataStore instance of RatingDataStore
- * @property { string } username username of rating author
- * @returns { Promise<Rating[]> }
- */
-export async function getUsersRatings(params: {
-    username: string;
-}): Promise<Rating[]> {
-    try {
-        const ratings = await getDataStore().getUsersRatings({
-            username: params.username,
-        });
-        return ratings;
-    } catch (error) {
-        reportError(error);
-        return Promise.reject(
-            new ServiceError(
-                ServiceErrorReason.INTERNAL,
-            ),
-        );
-    }
-}
-
 function getDataStore() {
     return RatingStore.getInstance();
 }

--- a/src/ratings/RatingsRouteHandler.ts
+++ b/src/ratings/RatingsRouteHandler.ts
@@ -1,7 +1,6 @@
 import { Request, Response, Router } from 'express';
 import * as interactor from './RatingsInteractor';
 import { mapErrorToStatusCode } from '../errors';
-import { RatingStore } from './RatingStore';
 
 /**
  * Initializes an express router with endpoints for public

--- a/src/ratings/interfaces/RatingDataStore.ts
+++ b/src/ratings/interfaces/RatingDataStore.ts
@@ -20,7 +20,4 @@ export interface RatingDataStore {
         learningObjectId: string;
         user: UserInfo;
     }): Promise<void>;
-    getUsersRatings(params: {
-        username: string;
-    }): Promise<any>;
 }

--- a/src/ratings/mocks/MockObjects.ts
+++ b/src/ratings/mocks/MockObjects.ts
@@ -30,10 +30,10 @@ export const MOCK_OBJECTS = {
             date: 123,
             response: [
                 {
-                _id: new ObjectId('5c5c8fda47c664308b131469'),
+                _id: '5c5c8fda47c664308b131469',
                 comment: 'This is a mock response',
                 date: 123,
-                source: new ObjectId('5ac520bdf5b97e186468964b'),
+                source: '5ac520bdf5b97e186468964b',
                 user: {
                     email: 'email@email',
                     name: 'name',
@@ -45,7 +45,7 @@ export const MOCK_OBJECTS = {
                 name: 'name',
                 username: 'username',
             },
-            value: 2
+            value: 2,
         }]},
     USER_GROUPING : {
         _id: '5ac520bdf5b97e1864689123',


### PR DESCRIPTION
$toString requires Mongo v4

@DonSeannelly - "The issue with ratings service is that our production cluster is running version 3.6.10 of Mongo, and `$toString` requires 4.X"

This PR replaces the use of $toString with helper methods that map all ObjectIds to strings