### PR TITLE
Add check for null id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-ratings",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-ratings",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A microservice for handlingy learning object ratings in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/ratings/RatingStore.ts
+++ b/src/ratings/RatingStore.ts
@@ -156,8 +156,11 @@ export class RatingStore implements RatingDataStore {
             },
           ],
         ).toArray();
-        const result = this.convertMongoId(data[0]);
-        return result;
+        if (data.length > 0) {
+          const result = this.convertMongoId(data[0]);
+          return result;
+        }
+        return data[0];
       } catch (error) {
         reportError(error);
         return Promise.reject(new ServiceError(
@@ -228,4 +231,3 @@ export class RatingStore implements RatingDataStore {
       return {...response, _id: response._id.toString(), source: response.source.toString() };
     }
 }
-


### PR DESCRIPTION
In response to Sentry Error: https://sentry.io/organizations/cyber4all/issues/908646787/?project=1402467&query=is%3Aunresolved&statsPeriod=14d&utc=false

route to fetch learning object ratings should return a 200 even if the object does not have any ratings