### PR TITLE
Run process token middleware after cookie parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-ratings",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-ratings",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A microservice for handlingy learning object ratings in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressDriver.ts
+++ b/src/drivers/express/ExpressDriver.ts
@@ -15,7 +15,6 @@ export class ExpressDriver {
     static start(
     ) {
       Sentry.init({ dsn: process.env.SENTRY_URI });
-      this.app.use(processToken, handleProcessTokenError);
       this.app.use(Sentry.Handlers.requestHandler() as express.RequestHandler);
       this.app.use(Sentry.Handlers.errorHandler() as express.ErrorRequestHandler);
       // configure app to use bodyParser()
@@ -37,6 +36,7 @@ export class ExpressDriver {
       );
       // Set up cookie parser
       this.app.use(cookieParser());
+      this.app.use(processToken, handleProcessTokenError);
 
       // Set our public api routes
       this.app.use(


### PR DESCRIPTION
***Purpose***
This PR moves the process token middleware after the cookie parser middleware. This was causing a bug where only requests with bearer tokens were authenticated. 