### PR TITLE
Fix bug with malformed link on rating submission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-ratings",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-ratings",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A microservice for handlingy learning object ratings in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/ratings/gateways/SlackGateway.ts
+++ b/src/ratings/gateways/SlackGateway.ts
@@ -68,7 +68,6 @@ export class SlackGateway implements RatingNotifier {
                 }),
                 method: 'POST',
             };
-            console.log(options.body);
             await request(options);
         } else {
             console.log('Sent to Slack');

--- a/src/ratings/gateways/SlackGateway.ts
+++ b/src/ratings/gateways/SlackGateway.ts
@@ -17,7 +17,7 @@ export class SlackGateway implements RatingNotifier {
     private initializePayload(params: {
         ratingAuthor: string,
         ratingComment: string,
-        learningObjectName: string,
+        learningObjectCuid: string,
         learningObjectAuthorUsername: string,
     }) {
         return {
@@ -27,12 +27,12 @@ export class SlackGateway implements RatingNotifier {
                     'fallback': `<https://clark.center/details/${
                             encodeURIComponent(params.learningObjectAuthorUsername)
                         }/${
-                            encodeURIComponent(params.learningObjectName)
+                            encodeURIComponent(params.learningObjectCuid)
                         }|View Rating>`,
                     'pretext': `<https://clark.center/details/${
                             encodeURIComponent(params.learningObjectAuthorUsername)
                         }/${
-                            encodeURIComponent(params.learningObjectName)
+                            encodeURIComponent(params.learningObjectCuid)
                         }|View Rating>`,
                     'color': '#0000ff',
                     'fields': [
@@ -53,7 +53,7 @@ export class SlackGateway implements RatingNotifier {
     async sendRatingNotification(params: {
         ratingAuthor: string;
         ratingComment: string;
-        learningObjectName: string;
+        learningObjectCuid: string;
         learningObjectAuthorUsername: string;
     }): Promise<void> {
         if (nodeEnv === 'production') {
@@ -63,11 +63,12 @@ export class SlackGateway implements RatingNotifier {
                 body: this.initializePayload({
                     ratingAuthor: params.ratingAuthor,
                     ratingComment: params.ratingComment,
-                    learningObjectAuthorUsername: params.learningObjectName,
-                    learningObjectName: params.learningObjectName,
+                    learningObjectAuthorUsername: params.learningObjectAuthorUsername,
+                    learningObjectCuid: params.learningObjectCuid,
                 }),
                 method: 'POST',
             };
+            console.log(options.body);
             await request(options);
         } else {
             console.log('Sent to Slack');

--- a/src/ratings/interactors/RatingsInteractor.ts
+++ b/src/ratings/interactors/RatingsInteractor.ts
@@ -213,7 +213,7 @@ export async function createRating(params: {
     await params.ratingNotifier.sendRatingNotification({
         ratingAuthor: params.user.username,
         ratingComment: params.rating.comment,
-        learningObjectName: learningObject.name,
+        learningObjectCuid: learningObject.cuid,
         learningObjectAuthorUsername: learningObject.author.username,
     });
 }

--- a/src/ratings/interactors/tests/createRating.spec.ts
+++ b/src/ratings/interactors/tests/createRating.spec.ts
@@ -21,7 +21,7 @@ class StubNotifier implements RatingNotifier {
     sendRatingNotification(params: {
         ratingAuthor: string;
         ratingComment: string;
-        learningObjectName: string;
+        learningObjectCuid: string;
         learningObjectAuthorUsername: string;
     }): Promise<void> {
         return;

--- a/src/ratings/interactors/tests/createRating.spec.ts
+++ b/src/ratings/interactors/tests/createRating.spec.ts
@@ -3,6 +3,17 @@ import { Rating } from '../../../types/Rating';
 import { createRating } from '../RatingsInteractor';
 import { UserToken } from '../../../types/UserToken';
 
+class StubNotifier implements RatingNotifier {
+    sendRatingNotification(params: {
+        ratingAuthor: string;
+        ratingComment: string;
+        learningObjectCuid: string;
+        learningObjectAuthorUsername: string;
+    }): Promise<void> {
+        return;
+    }
+}
+
 const stubRating: Rating = {
     value: 0,
     comment: 'test comment',
@@ -16,17 +27,6 @@ const stubUserToken: UserToken = {
     emailVerified: true,
     accessGroups: [''],
 };
-
-class StubNotifier implements RatingNotifier {
-    sendRatingNotification(params: {
-        ratingAuthor: string;
-        ratingComment: string;
-        learningObjectCuid: string;
-        learningObjectAuthorUsername: string;
-    }): Promise<void> {
-        return;
-    }
-}
 
 jest.mock('../../RatingStore', () => ({
     __esModule: true,

--- a/src/ratings/interfaces/RatingNotifier.ts
+++ b/src/ratings/interfaces/RatingNotifier.ts
@@ -8,7 +8,7 @@ export interface RatingNotifier {
      *
      * @param ratingAuthor [the username of the user that created the rating]
      * @param ratingComment [the comment that was left with the rating]
-     * @param learningObjectName [the name of the Learning Object]
+     * @param learningObjectCuid [the cuid of the learning object]
      * @param learningObjectAuthorUsername [the username of the user that created the Learning Object]
      */
     sendRatingNotification(params: {

--- a/src/ratings/interfaces/RatingNotifier.ts
+++ b/src/ratings/interfaces/RatingNotifier.ts
@@ -14,7 +14,7 @@ export interface RatingNotifier {
     sendRatingNotification(params: {
         ratingAuthor: string;
         ratingComment: string;
-        learningObjectName: string;
+        learningObjectCuid: string;
         learningObjectAuthorUsername: string;
     }): Promise<void>;
 }


### PR DESCRIPTION
This PR addresses the bug that would send a malformed link to slack when a rating was left on the system. 