### PR TITLE
Block the creation/update of ratings for Learning Objects that are not released

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1342,6 +1342,15 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -2829,6 +2838,12 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
       "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -3390,13 +3405,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+      "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -3406,7 +3422,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3424,32 +3441,37 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.4",
           "bundled": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3457,7 +3479,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -3480,11 +3502,11 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -3508,7 +3530,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -3534,7 +3556,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -3551,8 +3573,9 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
-          "bundled": true
+          "version": "2.0.4",
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3562,6 +3585,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3574,54 +3598,58 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
-          "version": "0.0.8",
-          "bundled": true
+          "version": "1.2.5",
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
+          "version": "0.5.3",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.3.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -3634,11 +3662,11 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
-          "version": "4.0.1",
+          "version": "4.0.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -3647,17 +3675,26 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.8",
           "bundled": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "npm-bundled": "^1.0.1",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npmlog": {
@@ -3673,7 +3710,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3683,6 +3721,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3712,7 +3751,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "optional": true
         },
@@ -3725,17 +3764,10 @@
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            }
           }
         },
         "readable-stream": {
-          "version": "2.3.6",
+          "version": "2.3.7",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -3749,7 +3781,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -3758,7 +3790,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3771,7 +3804,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "optional": true
         },
@@ -3788,6 +3821,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3805,6 +3839,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3815,17 +3850,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -3843,11 +3878,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
-          "bundled": true
+          "version": "3.1.1",
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-ratings",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-ratings",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "A microservice for handlingy learning object ratings in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/ratings/interactors/RatingsInteractor.ts
+++ b/src/ratings/interactors/RatingsInteractor.ts
@@ -72,6 +72,13 @@ export async function updateRating(params: {
         );
     }
 
+    if (learningObject.status !== 'released') {
+        throw new ResourceError(
+            'Invalid Access: You cannot update a review to an object in the review process',
+            ResourceErrorReason.INVALID_ACCESS
+        );
+    }
+
     await getDataStore().updateRating({
         ratingID: params.ratingID,
         updates: params.updates,
@@ -197,6 +204,14 @@ export async function createRating(params: {
         CUID: params.CUID,
         version: params.version,
     });
+
+    // Throw error if trying to write a rating to an in review object
+    if (learningObject.status !== 'released') {
+        throw new ResourceError(
+            'Invalid Access: You cannot write a review to an object in the review process',
+            ResourceErrorReason.INVALID_ACCESS
+        );
+    }
 
     const ratingUser = {
         username: params.user.username,

--- a/src/ratings/interactors/RatingsInteractor.ts
+++ b/src/ratings/interactors/RatingsInteractor.ts
@@ -75,7 +75,7 @@ export async function updateRating(params: {
     if (learningObject.status !== 'released') {
         throw new ResourceError(
             'Invalid Access: You cannot update a review to an object in the review process',
-            ResourceErrorReason.INVALID_ACCESS
+            ResourceErrorReason.INVALID_ACCESS,
         );
     }
 
@@ -209,7 +209,7 @@ export async function createRating(params: {
     if (learningObject.status !== 'released') {
         throw new ResourceError(
             'Invalid Access: You cannot write a review to an object in the review process',
-            ResourceErrorReason.INVALID_ACCESS
+            ResourceErrorReason.INVALID_ACCESS,
         );
     }
 

--- a/src/ratings/interactors/RatingsInteractor.ts
+++ b/src/ratings/interactors/RatingsInteractor.ts
@@ -74,7 +74,7 @@ export async function updateRating(params: {
 
     if (learningObject.status !== 'released') {
         throw new ResourceError(
-            'Invalid Access: You cannot update a review to an object in the review process',
+            'Invalid Access: You cannot write a review to an object in the review process or is unreleased',
             ResourceErrorReason.INVALID_ACCESS,
         );
     }
@@ -208,7 +208,7 @@ export async function createRating(params: {
     // Throw error if trying to write a rating to an in review object
     if (learningObject.status !== 'released') {
         throw new ResourceError(
-            'Invalid Access: You cannot write a review to an object in the review process',
+            'Invalid Access: You cannot write a review to an object in the review process or is unreleased',
             ResourceErrorReason.INVALID_ACCESS,
         );
     }

--- a/src/ratings/interactors/tests/createRating.spec.ts
+++ b/src/ratings/interactors/tests/createRating.spec.ts
@@ -100,6 +100,7 @@ describe('When createRating is called', () => {
                         author: {
                             username: 'learning_object_author',
                         },
+                        status: 'released',
                     };
                 });
                 await expect(createRating({
@@ -112,6 +113,30 @@ describe('When createRating is called', () => {
                 }))
                 .resolves
                 .not
+                .toThrowError();
+            });
+
+            it('should throw an error for a not released object', async () => {
+                getLearningObject['mockImplementation']((params: {
+                    CUID: string;
+                    version: string;
+                }): any => {
+                    return {
+                        author: {
+                            username: 'learning_object_author',
+                        },
+                        status: 'waiting',
+                    };
+                });
+                await expect(createRating({
+                    username: 'test_username',
+                    rating: stubRating,
+                    CUID: 'test_CUID',
+                    version: 'test_version',
+                    user: { ...stubUserToken },
+                    ratingNotifier: new StubNotifier(),
+                }))
+                .resolves
                 .toThrowError();
             });
         });

--- a/src/ratings/interactors/tests/createRating.spec.ts
+++ b/src/ratings/interactors/tests/createRating.spec.ts
@@ -136,7 +136,7 @@ describe('When createRating is called', () => {
                     user: { ...stubUserToken },
                     ratingNotifier: new StubNotifier(),
                 }))
-                .resolves
+                .rejects
                 .toThrowError();
             });
         });

--- a/src/ratings/interactors/tests/updateRating.spec.ts
+++ b/src/ratings/interactors/tests/updateRating.spec.ts
@@ -94,6 +94,7 @@ describe('When updateRating is called', () => {
                         author: {
                             username: 'learning_object_author',
                         },
+                        status: 'released',
                     };
                 });
 
@@ -107,6 +108,31 @@ describe('When updateRating is called', () => {
                 }))
                 .resolves
                 .not
+                .toThrowError();
+            });
+
+            it('should throw an error if it is not released', async () => {
+                getLearningObject['mockImplementation']((params: {
+                    CUID: string;
+                    version: string;
+                }): any => {
+                    return {
+                        author: {
+                            username: 'learning_object_author',
+                        },
+                        status: 'waiting',
+                    };
+                });
+
+                await expect(updateRating({
+                    username: 'test_username',
+                    ratingID: 'test_ratingID',
+                    CUID: 'test_CUID',
+                    updates: stubUpdates,
+                    version: 'test_version',
+                    user: { ...stubUserToken },
+                }))
+                .resolves
                 .toThrowError();
             });
         });

--- a/src/ratings/interactors/tests/updateRating.spec.ts
+++ b/src/ratings/interactors/tests/updateRating.spec.ts
@@ -132,7 +132,7 @@ describe('When updateRating is called', () => {
                     version: 'test_version',
                     user: { ...stubUserToken },
                 }))
-                .resolves
+                .rejects
                 .toThrowError();
             });
         });


### PR DESCRIPTION
Block the creation/update of ratings for Learning Objects that are not released.  Throws a 401 (may want to change to 403 in the future, API makes no mention of 403 currently) when trying to post a rating to a learning object that is unreleased, waiting, in review, or proofing.