### PR TITLE
3853/create-secured-team-email-domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "clark-ratings",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.4.9",
+      "version": "1.4.10",
       "license": "MIT",
       "dependencies": {
         "@cyber4all/clark-entity": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-ratings",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "A microservice for handlingy learning object ratings in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/SendgridDriver.ts
+++ b/src/drivers/SendgridDriver.ts
@@ -40,7 +40,7 @@ export class SendgridDriver {
         if (this.validateData(type, data)) {
             const msg = {
                 to,
-                from: 'no-reply@clark.center',
+                from: 'no-reply@secured.team',
                 subject: this.map.get(type),
                 templateId: type,
                 dynamic_template_data: data


### PR DESCRIPTION
Updates the from email to use secured.team domain.  Completes story [3853/create-secured-team-email-domain](https://app.clubhouse.io/clarkcan/story/3853/create-secured-team-email-domain).